### PR TITLE
feat: allow more than 1 image

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,16 +38,16 @@ hyprsnow [OPTIONS]
 
 ### Options
 
-| Option                  | Description                                                                      |
-|-------------------------|----------------------------------------------------------------------------------|
-| `--intensity <1-10>`    | Snow intensity (default: 3)                                                      |
-| `--size-min <float>`    | Minimum snowflake size in pixels (default: 2.0)                                  |
-| `--size-max <float>`    | Maximum snowflake size in pixels (default: 5.0)                                  |
-| `--speed-min <float>`   | Minimum fall speed in pixels/second (default: 30.0)                              |
-| `--speed-max <float>`   | Maximum fall speed in pixels/second (default: 80.0)                              |
-| `--drift <float>`       | Horizontal drift intensity, 0 = none, 30 = strong (default: 20.0)                |
-| `--max-opacity <float>` | Maximum snowflake opacity, 0.0 = invisible, 1.0 = solid (default: 1.0)           |
-| `--image-path <Path>`   | Set optional image path for snowflake. Otherwise the default circle will be used |
+| Option                   | Description                                                                      |
+|--------------------------|----------------------------------------------------------------------------------|
+| `--intensity <1-10>`     | Snow intensity (default: 3)                                                      |
+| `--size-min <float>`     | Minimum snowflake size in pixels (default: 2.0)                                  |
+| `--size-max <float>`     | Maximum snowflake size in pixels (default: 5.0)                                  |
+| `--speed-min <float>`    | Minimum fall speed in pixels/second (default: 30.0)                              |
+| `--speed-max <float>`    | Maximum fall speed in pixels/second (default: 80.0)                              |
+| `--drift <float>`        | Horizontal drift intensity, 0 = none, 30 = strong (default: 20.0)                |
+| `--max-opacity <float>`  | Maximum snowflake opacity, 0.0 = invisible, 1.0 = solid (default: 1.0)           |
+| `--image-paths <String>` | Set optional image path for snowflake. Otherwise the default circle will be used |
 
 ## Configuration
 
@@ -62,7 +62,7 @@ general {
     speed_max = 80.0
     drift = 20.0
     max_opacity = 1.0
-    image_path = "/path/to/snowflake/image.png"
+    image_paths = "/path/to/snowflake/image.png /path/to/snowflake/image2.png ..."
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # hyprsnow
 
-A snow overlay for Wayland/Hyprland. Snowflakes fall across your screen, land on window titlebars and the screen bottom, then melt away.
-
+A snow overlay for Wayland/Hyprland. Snowflakes fall across your screen, land on window titlebars and the screen bottom,
+then melt away.
 
 https://github.com/user-attachments/assets/634c215b-2aa7-40e0-9172-222355349400
 
 ## Note
+
 This is a project made for fun and not tested for performance or battery usage.
 
 ## Quickstart
@@ -20,10 +21,13 @@ cargo run
 cargo build --release
 cp target/release/hyprsnow ~/.local/bin/
 ```
+
 OR
+
 ```
 cargo install hyprsnow
 ```
+
 OR
 
 ```
@@ -38,16 +42,16 @@ hyprsnow [OPTIONS]
 
 ### Options
 
-| Option                   | Description                                                                      |
-|--------------------------|----------------------------------------------------------------------------------|
-| `--intensity <1-10>`     | Snow intensity (default: 3)                                                      |
-| `--size-min <float>`     | Minimum snowflake size in pixels (default: 2.0)                                  |
-| `--size-max <float>`     | Maximum snowflake size in pixels (default: 5.0)                                  |
-| `--speed-min <float>`    | Minimum fall speed in pixels/second (default: 30.0)                              |
-| `--speed-max <float>`    | Maximum fall speed in pixels/second (default: 80.0)                              |
-| `--drift <float>`        | Horizontal drift intensity, 0 = none, 30 = strong (default: 20.0)                |
-| `--max-opacity <float>`  | Maximum snowflake opacity, 0.0 = invisible, 1.0 = solid (default: 1.0)           |
-| `--image-paths <String>` | Set optional image path for snowflake. Otherwise the default circle will be used |
+| Option                    | Description                                                                                                                                          |
+|---------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `--intensity <1-10>`      | Snow intensity (default: 3)                                                                                                                          |
+| `--size-min <float>`      | Minimum snowflake size in pixels (default: 2.0)                                                                                                      |
+| `--size-max <float>`      | Maximum snowflake size in pixels (default: 5.0)                                                                                                      |
+| `--speed-min <float>`     | Minimum fall speed in pixels/second (default: 30.0)                                                                                                  |
+| `--speed-max <float>`     | Maximum fall speed in pixels/second (default: 80.0)                                                                                                  |
+| `--drift <float>`         | Horizontal drift intensity, 0 = none, 30 = strong (default: 20.0)                                                                                    |
+| `--max-opacity <float>`   | Maximum snowflake opacity, 0.0 = invisible, 1.0 = solid (default: 1.0)                                                                               |
+| `--image-path <String[]>` | Optional list of image file paths used for rendering snowflakes. If not provided, or if the list is empty, default circular snowflakes will be used. |
 
 ## Configuration
 
@@ -67,11 +71,13 @@ general {
 }
 ```
 
-**Note: CLI arguments override config file values unless you changed the config after starting hyprsnow.  Hotreload changes supercede CLI args.**
+**Note: CLI arguments override config file values unless you changed the config after starting hyprsnow. Hotreload
+changes supercede CLI args.**
 
 ## Hyprland Integration
 
-hyprsnow listens to Hyprland IPC events and updates window positions in real-time. Snowflakes will land on the top edge of your windows as you open, close, move, or resize them.
+hyprsnow listens to Hyprland IPC events and updates window positions in real-time. Snowflakes will land on the top edge
+of your windows as you open, close, move, or resize them.
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -38,16 +38,16 @@ hyprsnow [OPTIONS]
 
 ### Options
 
-| Option                  | Description                                                                      |
-|-------------------------|----------------------------------------------------------------------------------|
-| `--intensity <1-10>`    | Snow intensity (default: 3)                                                      |
-| `--size-min <float>`    | Minimum snowflake size in pixels (default: 2.0)                                  |
-| `--size-max <float>`    | Maximum snowflake size in pixels (default: 5.0)                                  |
-| `--speed-min <float>`   | Minimum fall speed in pixels/second (default: 30.0)                              |
-| `--speed-max <float>`   | Maximum fall speed in pixels/second (default: 80.0)                              |
-| `--drift <float>`       | Horizontal drift intensity, 0 = none, 30 = strong (default: 20.0)                |
-| `--max-opacity <float>` | Maximum snowflake opacity, 0.0 = invisible, 1.0 = solid (default: 1.0)           |
-| `--image-path <Path>`   | Set optional image path for snowflake. Otherwise the default circle will be used |
+| Option                   | Description                                                                      |
+|--------------------------|----------------------------------------------------------------------------------|
+| `--intensity <1-10>`     | Snow intensity (default: 3)                                                      |
+| `--size-min <float>`     | Minimum snowflake size in pixels (default: 2.0)                                  |
+| `--size-max <float>`     | Maximum snowflake size in pixels (default: 5.0)                                  |
+| `--speed-min <float>`    | Minimum fall speed in pixels/second (default: 30.0)                              |
+| `--speed-max <float>`    | Maximum fall speed in pixels/second (default: 80.0)                              |
+| `--drift <float>`        | Horizontal drift intensity, 0 = none, 30 = strong (default: 20.0)                |
+| `--max-opacity <float>`  | Maximum snowflake opacity, 0.0 = invisible, 1.0 = solid (default: 1.0)           |
+| `--image-paths <String>` | Set optional image path for snowflake. Otherwise the default circle will be used |
 
 ## Configuration
 
@@ -62,7 +62,7 @@ general {
     speed_max = 80.0
     drift = 20.0
     max_opacity = 1.0
-    #image_path = "/path/to/snowflake/image.png"
+    #image_paths = "/path/to/snowflake/image.png /path/to/snowflake/image2.png"
 }
 ```
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -36,5 +36,5 @@ pub struct Args {
     /// If not provided, default circle shape will be used
     /// Make sure the image has a transparent background (e.g., PNG format)
     #[arg(long, num_args(1..))]
-    pub image_paths: Option<Vec<String>>,
+    pub image_path: Option<Vec<String>>,
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -35,6 +35,6 @@ pub struct Args {
     /// Path to custom snowflake image
     /// If not provided, default circle shape will be used
     /// Make sure the image has a transparent background (e.g., PNG format)
-    #[arg(long)]
-    pub image_path: Option<String>,
+    #[arg(long, num_args(1..))]
+    pub image_paths: Option<Vec<String>>,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -60,6 +60,12 @@ pub fn load_config() -> SnowConfig {
     };
 
     let mut config = hyprlang::Config::new();
+
+    config.register_category_handler_fn("general", "image_path", |ctx| {
+        println!("Got image path: {}", ctx.value);
+        Ok(())
+    });
+
     if config.parse_file(&path).is_err() {
         return SnowConfig::default();
     }
@@ -94,13 +100,9 @@ pub fn load_config() -> SnowConfig {
             .map(|v| (v as f32).clamp(0.0, 1.0))
             .unwrap_or(1.0),
         image_paths: config
-            .get_string("general:image_paths")
-            .map(|s| {
-                s.split_whitespace()
-                    .map(|p| p.to_string())
-                    .collect::<Vec<String>>()
-            }).ok()
-            .filter(|v| !v.is_empty()),
+            .get_handler_calls("general:image_path")
+            .filter(|v| !v.is_empty())
+            .map(|v| v.clone()),
     }
 }
 
@@ -125,6 +127,9 @@ pub fn apply_cli_overrides(config: &mut SnowConfig, args: &Args) {
     }
     if let Some(v) = args.max_opacity {
         config.max_opacity = v.clamp(0.0, 1.0);
+    }
+    if let Some(v) = &args.image_path {
+        config.image_paths = Some(v.clone());
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,7 +14,7 @@ pub struct SnowConfig {
     pub speed_max: f32,
     pub drift: f32,
     pub max_opacity: f32,
-    pub image_path: Option<String>,
+    pub image_paths: Option<Vec<String>>,
 }
 
 #[derive(Debug, Clone)]
@@ -32,7 +32,7 @@ impl Default for SnowConfig {
             speed_max: 80.0,
             drift: 20.0,
             max_opacity: 1.0,
-            image_path: None,
+            image_paths: None,
         }
     }
 }
@@ -93,10 +93,14 @@ pub fn load_config() -> SnowConfig {
             .get_float("general:max_opacity")
             .map(|v| (v as f32).clamp(0.0, 1.0))
             .unwrap_or(1.0),
-        image_path: config
-            .get_string("general:image_path")
-            .map(|s| s.to_string())
-            .ok(),
+        image_paths: config
+            .get_string("general:image_paths")
+            .map(|s| {
+                s.split_whitespace()
+                    .map(|p| p.to_string())
+                    .collect::<Vec<String>>()
+            }).ok()
+            .filter(|v| !v.is_empty()),
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -102,7 +102,7 @@ pub fn load_config() -> SnowConfig {
         image_paths: config
             .get_handler_calls("general:image_path")
             .filter(|v| !v.is_empty())
-            .map(|v| v.clone()),
+            .cloned()
     }
 }
 


### PR DESCRIPTION
This change allows the user to specify multiple image paths in the configuration using whitespace-separated paths.

Notes:
- Chose whitespace-separated paths in config as a temporary solution because hyprlang does not support lists by default