### PR TITLE
fix: empty range bug with disabled monitor

### DIFF
--- a/src/hyprland.rs
+++ b/src/hyprland.rs
@@ -83,6 +83,7 @@ pub fn get_monitors_with_fullscreen_state() -> Vec<MonitorRect> {
 
     monitors
         .iter()
+        .filter(|m| !m.disabled)
         .map(|monitor| {
             let has_fullscreen = workspaces
                 .as_ref()


### PR DESCRIPTION
got: thread 'main' panicked at src/snow.rs:303:47:
cannot sample empty range caused by passing disabled monitors
